### PR TITLE
Minor change on Liquid Demo app interface

### DIFF
--- a/LiquidDemo/Base.lproj/LiquidDemo.storyboard
+++ b/LiquidDemo/Base.lproj/LiquidDemo.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
@@ -86,34 +86,34 @@
                                 </connections>
                             </button>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="User Identification" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-ue-Psb">
-                                <rect key="frame" x="89" y="98" width="140" height="21"/>
+                                <rect key="frame" x="88" y="84" width="140" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="3" translatesAutoresizingMaskIntoConstraints="NO" id="nBc-2J-9vY">
-                                <rect key="frame" x="19" y="132" width="280" height="29"/>
+                                <rect key="frame" x="20" y="142" width="280" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <segments>
                                     <segment title="100"/>
                                     <segment title="101"/>
                                     <segment title="102"/>
-                                    <segment title="Auto"/>
+                                    <segment title="103"/>
                                 </segments>
                                 <connections>
                                     <action selector="profileSelectorPressed:" destination="vXZ-lx-hvc" eventType="valueChanged" id="JQm-w7-XWm"/>
                                 </connections>
                             </segmentedControl>
                             <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="22" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="D04-9N-cns">
-                                <rect key="frame" x="-1" y="181" width="339" height="70"/>
+                                <rect key="frame" x="0.0" y="197" width="320" height="70"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PropertyCell" textLabel="Og0-ey-4GI" detailTextLabel="KEV-db-seS" rowHeight="22" style="IBUITableViewCellStyleValue2" id="0Te-mn-BbT">
-                                        <rect key="frame" x="0.0" y="22" width="339" height="22"/>
+                                        <rect key="frame" x="0.0" y="22" width="320" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0Te-mn-BbT" id="y6v-09-jFT">
-                                            <rect key="frame" x="0.0" y="0.0" width="339" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="21"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Og0-ey-4GI">
@@ -152,7 +152,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m9I-Bb-Bs2">
-                                <rect key="frame" x="33" y="24" width="75" height="30"/>
+                                <rect key="frame" x="20" y="20" width="75" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Reset SDK">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -162,7 +162,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jwh-oY-XVC">
-                                <rect key="frame" x="138" y="24" width="149" height="30"/>
+                                <rect key="frame" x="150" y="20" width="149" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Flush HTTP Requests">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -235,16 +235,27 @@ the app goes into background.</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="User Unique ID" textAlignment="center" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="320" translatesAutoresizingMaskIntoConstraints="NO" id="L0n-0m-wT1">
-                                <rect key="frame" x="0.0" y="163" width="320" height="16"/>
+                                <rect key="frame" x="0.0" y="173" width="320" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cHw-2G-4bV">
+                                <rect key="frame" x="119" y="104" width="82" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Anonymous">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="IdentifyAnonymousButton:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Spw-ET-xSG"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <nil key="simulatedStatusBarMetrics"/>
                     <connections>
+                        <outlet property="anonymousUserButton" destination="cHw-2G-4bV" id="LJI-R8-vjD"/>
                         <outlet property="autoLoadValuesSwitch" destination="W4m-wW-fLi" id="i1v-Dc-IOH"/>
                         <outlet property="bgColorLabel" destination="qUq-sR-HOI" id="93c-mV-qdi"/>
                         <outlet property="bgColorSquare" destination="nqr-Nu-eOc" id="0ZG-hA-e9p"/>

--- a/LiquidDemo/LiquidDemoViewController.h
+++ b/LiquidDemo/LiquidDemoViewController.h
@@ -21,5 +21,6 @@
 @property (strong, nonatomic) IBOutlet UISegmentedControl *userSelectorSegmentedControl;
 @property (strong, nonatomic) IBOutlet UITableView *userAttributesTableView;
 @property (strong, nonatomic) IBOutlet UILabel *userUniqueId;
+@property (strong, nonatomic) IBOutlet UIButton *anonymousUserButton;
 
 @end

--- a/LiquidDemo/LiquidDemoViewController.m
+++ b/LiquidDemo/LiquidDemoViewController.m
@@ -33,11 +33,12 @@ BOOL const defaultShowAds = YES;
 
 - (NSDictionary *)userProfiles {
     if (!_userProfiles) {
-        NSDictionary *user1Attributes = @{ @"name": @"Anna Martinez", @"age": @25, @"gender": @"female" };
-        NSDictionary *user2Attributes = @{ @"name": @"John Clark", @"age": @37, @"gender": @"male" };
-        NSDictionary *user3Attributes = @{ @"name": @"Barry Hill", @"age": @16, @"gender": @"male" };
-        _userProfiles = [NSDictionary dictionaryWithObjectsAndKeys:user1Attributes, @"100",
-                         user2Attributes, @"101", user3Attributes, @"102", nil];
+        NSDictionary *user0Attributes = @{ @"name": @"Anna Martinez", @"age": @25, @"gender": @"female" };
+        NSDictionary *user1Attributes = @{ @"name": @"John Clark", @"age": @37, @"gender": @"male" };
+        NSDictionary *user2Attributes = @{ @"name": @"Barry Hill", @"age": @16, @"gender": @"male" };
+        NSDictionary *user3Attributes = @{ @"name": @"Guilherme Alves", @"age": @1, @"gender": @"male" };
+        _userProfiles = [NSDictionary dictionaryWithObjectsAndKeys:user0Attributes, @"100",
+                         user1Attributes, @"101", user2Attributes, @"102", user3Attributes, @"103", nil];
     }
     return _userProfiles;
 }
@@ -58,7 +59,7 @@ BOOL const defaultShowAds = YES;
         [self.userSelectorSegmentedControl setSelectedSegmentIndex:1];
     } else if ([currentUserIdentifier isEqualToString:@"102"]) {
         [self.userSelectorSegmentedControl setSelectedSegmentIndex:2];
-    } else {
+    } else if ([currentUserIdentifier isEqualToString:@"103"]) {
         [self.userSelectorSegmentedControl setSelectedSegmentIndex:3];
     }
 
@@ -180,16 +181,19 @@ BOOL const defaultShowAds = YES;
     NSLog(@"discount: %f", discount);
     NSLog(@"showAds: %@", (showAds ? @"yes" : @"no"));
 }
+- (IBAction)IdentifyAnonymousButton:(UIButton *)sender {
+    [[Liquid sharedInstance] resetUser];
+    [sender setSelected:YES];
+    // Unselect all Segmented Control buttons
+    [self.userSelectorSegmentedControl setSelectedSegmentIndex:UISegmentedControlNoSegment];
+}
 
 - (void)setCurrentUserWithIdentifier:(NSString *)userIdentifier {
     NSDictionary *userAttributes = [self.userProfiles objectForKey:userIdentifier];
-    if ([userIdentifier isEqualToString:@"103"]) {
-        [[Liquid sharedInstance] resetUser];
-    } else {
-        [[Liquid sharedInstance] identifyUserWithIdentifier:userIdentifier attributes:userAttributes];
-    }
+    [[Liquid sharedInstance] identifyUserWithIdentifier:userIdentifier attributes:userAttributes];
 
     // Update interface:
+    self.anonymousUserButton.selected = false;
     self.selectedUserProfile = userIdentifier;
     self.userUniqueId.text = [[Liquid sharedInstance] userIdentifier];
 }


### PR DESCRIPTION
Move the anonymous user identifier into its own button, allowing one to
identify an anonymous user multiple times successively.
Also reuse the last segmented control discrete button to add a new
identified user.

This should allow more freedom on switching users and will allow us to
replicate some bugs caused by edge case uses of the identify user with
anonymous.
